### PR TITLE
feat(proxy): 添加WARP代理支持到Puppeteer

### DIFF
--- a/server.js
+++ b/server.js
@@ -80,13 +80,29 @@ async function runPuppeteerTask() {
     log(`运行模式: ${isLocal ? '本地测试' : '生产环境'}`);
 
     log('启动浏览器...');
+
+    // 检查WARP代理配置
+    const warpEnabled = process.env.WARP_ENABLED === 'true';
+    const warpSocks5Host = process.env.WARP_SOCKS5_HOST;
+    const warpSocks5Port = process.env.WARP_SOCKS5_PORT;
+
+    const launchArgs = [
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+      '--disable-dev-shm-usage',
+    ];
+
+    // 如果启用WARP代理，添加代理参数
+    if (warpEnabled && warpSocks5Host && warpSocks5Port) {
+      launchArgs.push(`--proxy-server=socks5://${warpSocks5Host}:${warpSocks5Port}`);
+      log(`启用WARP代理: socks5://${warpSocks5Host}:${warpSocks5Port}`);
+    } else if (warpEnabled) {
+      log('警告: WARP_ENABLED为true，但未设置WARP_SOCKS5_HOST或WARP_SOCKS5_PORT');
+    }
+
     const browser = await puppeteer.launch({
       headless: true,
-      args: [
-        '--no-sandbox',
-        '--disable-setuid-sandbox',
-        '--disable-dev-shm-usage',
-      ],
+      args: launchArgs,
       ...(isLocal ? { slowMo: 50 } : {}),
     });
     const page = await browser.newPage();

--- a/start-warp.sh
+++ b/start-warp.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# WARP WireProxy 启动脚本
+# 用于启动WireProxy并设置环境变量供Puppeteer使用
+
+set -e
+
+echo "启动WARP WireProxy..."
+
+# 检查wireproxy是否已安装
+if ! command -v wireproxy &> /dev/null; then
+    echo "WireProxy未安装，尝试安装..."
+    go install github.com/pufferffish/wireproxy/cmd/wireproxy@latest
+fi
+
+# 检查配置文件是否存在
+if [ ! -f "wireproxy.conf" ]; then
+    echo "错误: wireproxy.conf配置文件不存在"
+    exit 1
+fi
+
+# 启动WireProxy
+echo "启动WireProxy..."
+wireproxy -c wireproxy.conf &
+
+# 等待WireProxy启动
+sleep 3
+
+# 设置环境变量
+export WARP_ENABLED=true
+export WARP_SOCKS5_HOST=127.0.0.1
+export WARP_SOCKS5_PORT=1080
+
+echo "WARP WireProxy已启动"
+echo "SOCKS5代理地址: socks5://127.0.0.1:1080"
+echo "环境变量已设置:"
+echo "  WARP_ENABLED=$WARP_ENABLED"
+echo "  WARP_SOCKS5_HOST=$WARP_SOCKS5_HOST"
+echo "  WARP_SOCKS5_PORT=$WARP_SOCKS5_PORT"
+
+# 保持脚本运行
+wait

--- a/wgcf-profile.conf.template
+++ b/wgcf-profile.conf.template
@@ -1,0 +1,9 @@
+[Interface]
+PrivateKey = YOUR_PRIVATE_KEY_HERE
+Address = 172.16.0.2/32
+DNS = 1.1.1.1
+
+[Peer]
+PublicKey = bmXOC+F1FxEMF9dyiK2H5/1SUtzH0JuVo51h2wPfgyo=
+Endpoint = engage.cloudflareclient.com:2408
+AllowedIPs = 0.0.0.0/0

--- a/wireproxy.conf
+++ b/wireproxy.conf
@@ -1,0 +1,16 @@
+# WireProxy configuration for WARP
+# This file should be generated from wgcf-profile.conf
+
+[Interface]
+Address = 172.16.0.2/32
+PrivateKey = YOUR_PRIVATE_KEY_HERE
+DNS = 1.1.1.1
+
+[Peer]
+PublicKey = bmXOC+F1FxEMF9dyiK2H5/1SUtzH0JuVo51h2wPfgyo=
+Endpoint = engage.cloudflareclient.com:2408
+AllowedIPs = 0.0.0.0/0
+
+# SOCKS5 proxy for Puppeteer
+[Socks5]
+BindAddress = 127.0.0.1:1080


### PR DESCRIPTION
添加WireProxy配置和启动脚本，实现通过SOCKS5代理增强Puppeteer的网络访问能力。
新增配置文件模板和代理启动脚本，支持环境变量控制代理启用。