### PR TITLE
Warp proxy ip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ logs
 *.sln
 *.sw?
 cookies.txt
+wgcf-account.toml
+wgcf_2.2.26_linux_amd64
+wgcf_2.2.29_linux_amd64
+wgcf-profile.conf

--- a/build-render.sh
+++ b/build-render.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Render平台构建脚本
+# 安装必要的依赖：Go和WireProxy
+
+set -e
+
+echo "开始Render构建过程..."
+
+# 安装系统依赖
+echo "安装系统依赖..."
+apt-get update && apt-get install -y wget
+
+# 安装Go
+echo "安装Go..."
+wget -q https://go.dev/dl/go1.21.5.linux-amd64.tar.gz
+tar -C /usr/local -xzf go1.21.5.linux-amd64.tar.gz
+export PATH=$PATH:/usr/local/go/bin
+echo "export PATH=$PATH:/usr/local/go/bin" >> ~/.bashrc
+
+# 验证Go安装
+go version
+
+# 安装WireProxy
+echo "安装WireProxy..."
+go install github.com/pufferffish/wireproxy/cmd/wireproxy@latest
+
+# 验证WireProxy安装
+wireproxy --version
+
+echo "WireProxy安装完成"
+
+# 清理安装文件
+rm go1.21.5.linux-amd64.tar.gz
+
+echo "构建过程完成"

--- a/build-render.sh
+++ b/build-render.sh
@@ -24,6 +24,12 @@ wireproxy --version
 
 echo "WireProxy安装完成"
 
+# 安装Chrome浏览器
+echo "安装Chrome浏览器..."
+npx puppeteer browsers install chrome
+
+echo "Chrome浏览器安装完成"
+
 # 清理安装文件
 rm wireproxy_linux_amd64.tar.gz
 

--- a/build-render.sh
+++ b/build-render.sh
@@ -7,10 +7,6 @@ set -e
 
 echo "开始Render构建过程..."
 
-# 安装系统依赖
-echo "安装系统依赖..."
-apt-get update && apt-get install -y wget
-
 # 下载预编译的WireProxy二进制文件
 echo "下载WireProxy预编译二进制文件..."
 wget -q https://github.com/whyvl/wireproxy/releases/download/v1.0.9/wireproxy_linux_amd64.tar.gz
@@ -19,6 +15,9 @@ wget -q https://github.com/whyvl/wireproxy/releases/download/v1.0.9/wireproxy_li
 echo "解压WireProxy..."
 tar -xzf wireproxy_linux_amd64.tar.gz
 chmod +x wireproxy
+
+# 设置PATH包含当前目录
+export PATH="$PWD:$PATH"
 
 # 验证WireProxy安装
 wireproxy --version

--- a/build-render.sh
+++ b/build-render.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Render平台构建脚本
-# 安装必要的依赖：Go和WireProxy
+# 安装必要的依赖：WireProxy预编译二进制文件
 
 set -e
 
@@ -11,19 +11,14 @@ echo "开始Render构建过程..."
 echo "安装系统依赖..."
 apt-get update && apt-get install -y wget
 
-# 安装Go
-echo "安装Go..."
-wget -q https://go.dev/dl/go1.21.5.linux-amd64.tar.gz
-tar -C /usr/local -xzf go1.21.5.linux-amd64.tar.gz
-export PATH=$PATH:/usr/local/go/bin
-echo "export PATH=$PATH:/usr/local/go/bin" >> ~/.bashrc
+# 下载预编译的WireProxy二进制文件
+echo "下载WireProxy预编译二进制文件..."
+wget -q https://github.com/whyvl/wireproxy/releases/download/v1.0.9/wireproxy_linux_amd64.tar.gz
 
-# 验证Go安装
-go version
-
-# 安装WireProxy
-echo "安装WireProxy..."
-go install github.com/pufferffish/wireproxy/cmd/wireproxy@latest
+# 解压WireProxy
+echo "解压WireProxy..."
+tar -xzf wireproxy_linux_amd64.tar.gz
+chmod +x wireproxy
 
 # 验证WireProxy安装
 wireproxy --version
@@ -31,6 +26,6 @@ wireproxy --version
 echo "WireProxy安装完成"
 
 # 清理安装文件
-rm go1.21.5.linux-amd64.tar.gz
+rm wireproxy_linux_amd64.tar.gz
 
 echo "构建过程完成"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "start": "node server.js",
     "test": "NODE_ENV=test node server.js",
-    "puppeteer": "node index.js"
+    "puppeteer": "node index.js",
+    "render": "./start-render.sh",
+    "build-render": "./build-render.sh"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/server.js
+++ b/server.js
@@ -391,16 +391,16 @@ app.get('/', (req, res) => {
                     const result = await response.json();
 
                     if (result.success) {
-                        resultDiv.textContent = `[成功] WARP出口IP测试成功!\n出口IP: ${result.ip}\n代理: ${result.proxy}`;
+                        resultDiv.textContent = '[成功] WARP出口IP测试成功!\\n出口IP: ' + result.ip + '\\n代理: ' + result.proxy;
                         resultDiv.style.backgroundColor = '#d4edda';
                         resultDiv.style.color = '#155724';
                     } else {
-                        resultDiv.textContent = `[失败] 测试失败: ${result.message}`;
+                        resultDiv.textContent = '[失败] 测试失败: ' + result.message;
                         resultDiv.style.backgroundColor = '#f8d7da';
                         resultDiv.style.color = '#721c24';
                     }
                 } catch (error) {
-                    resultDiv.textContent = `[错误] 请求失败: ${error.message}`;
+                    resultDiv.textContent = '[错误] 请求失败: ' + error.message;
                     resultDiv.style.backgroundColor = '#f8d7da';
                     resultDiv.style.color = '#721c24';
                 }

--- a/server.js
+++ b/server.js
@@ -80,13 +80,29 @@ async function runPuppeteerTask() {
     log(`运行模式: ${isLocal ? '本地测试' : '生产环境'}`);
 
     log('启动浏览器...');
+
+    // 检查WARP代理配置
+    const warpEnabled = process.env.WARP_ENABLED === 'true';
+    const warpSocks5Host = process.env.WARP_SOCKS5_HOST;
+    const warpSocks5Port = process.env.WARP_SOCKS5_PORT;
+
+    const launchArgs = [
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+      '--disable-dev-shm-usage',
+    ];
+
+    // 如果启用WARP代理，添加代理参数
+    if (warpEnabled && warpSocks5Host && warpSocks5Port) {
+      launchArgs.push(`--proxy-server=socks5://${warpSocks5Host}:${warpSocks5Port}`);
+      log(`启用WARP代理: socks5://${warpSocks5Host}:${warpSocks5Port}`);
+    } else if (warpEnabled) {
+      log('警告: WARP_ENABLED为true，但未设置WARP_SOCKS5_HOST或WARP_SOCKS5_PORT');
+    }
+
     const browser = await puppeteer.launch({
       headless: true,
-      args: [
-        '--no-sandbox',
-        '--disable-setuid-sandbox',
-        '--disable-dev-shm-usage',
-      ],
+      args: launchArgs,
       ...(isLocal ? { slowMo: 50 } : {}),
     });
     const page = await browser.newPage();

--- a/server.js
+++ b/server.js
@@ -391,16 +391,16 @@ app.get('/', (req, res) => {
                     const result = await response.json();
 
                     if (result.success) {
-                        resultDiv.textContent = `✅ WARP出口IP测试成功!\n出口IP: ${result.ip}\n代理: ${result.proxy}`;
+                        resultDiv.textContent = `[成功] WARP出口IP测试成功!\n出口IP: ${result.ip}\n代理: ${result.proxy}`;
                         resultDiv.style.backgroundColor = '#d4edda';
                         resultDiv.style.color = '#155724';
                     } else {
-                        resultDiv.textContent = `❌ 测试失败: ${result.message}`;
+                        resultDiv.textContent = `[失败] 测试失败: ${result.message}`;
                         resultDiv.style.backgroundColor = '#f8d7da';
                         resultDiv.style.color = '#721c24';
                     }
                 } catch (error) {
-                    resultDiv.textContent = `❌ 请求失败: ${error.message}`;
+                    resultDiv.textContent = `[错误] 请求失败: ${error.message}`;
                     resultDiv.style.backgroundColor = '#f8d7da';
                     resultDiv.style.color = '#721c24';
                 }

--- a/server.js
+++ b/server.js
@@ -309,7 +309,9 @@ app.get('/', (req, res) => {
             <div id="status" class="status idle">状态: 空闲</div>
             <button id="runBtn" class="run-btn" onclick="runTask()">运行任务</button>
             <button onclick="checkStatus()">刷新状态</button>
+            <button onclick="testWarpIp()" style="background-color: #17a2b8; color: white; border: none; padding: 10px 20px; margin: 5px; cursor: pointer;">测试WARP出口IP</button>
             <div id="lastRun">最后运行时间: 从未运行</div>
+            <div id="warpTestResult" style="margin: 10px 0; padding: 10px; background-color: #f8f9fa; border-radius: 5px; display: none;"></div>
 
             <h2 style="margin-top: 30px;">定时设置</h2>
             <div style="margin: 20px 0; padding: 15px; background-color: #f8f9fa; border-radius: 5px;">
@@ -374,6 +376,33 @@ app.get('/', (req, res) => {
                     updateStatus(data);
                 } catch (error) {
                     console.error('获取状态失败:', error);
+                }
+            }
+
+            async function testWarpIp() {
+                const resultDiv = document.getElementById('warpTestResult');
+                resultDiv.style.display = 'block';
+                resultDiv.textContent = '正在测试WARP出口IP...';
+                resultDiv.style.backgroundColor = '#fff3cd';
+                resultDiv.style.color = '#856404';
+
+                try {
+                    const response = await fetch('/test-warp-ip');
+                    const result = await response.json();
+
+                    if (result.success) {
+                        resultDiv.textContent = `✅ WARP出口IP测试成功!\n出口IP: ${result.ip}\n代理: ${result.proxy}`;
+                        resultDiv.style.backgroundColor = '#d4edda';
+                        resultDiv.style.color = '#155724';
+                    } else {
+                        resultDiv.textContent = `❌ 测试失败: ${result.message}`;
+                        resultDiv.style.backgroundColor = '#f8d7da';
+                        resultDiv.style.color = '#721c24';
+                    }
+                } catch (error) {
+                    resultDiv.textContent = `❌ 请求失败: ${error.message}`;
+                    resultDiv.style.backgroundColor = '#f8d7da';
+                    resultDiv.style.color = '#721c24';
                 }
             }
 
@@ -536,6 +565,79 @@ app.get('/status', requireAuth, (req, res) => {
     isRunning,
     lastRunTime: lastRunTime ? format(lastRunTime, 'yyyy-MM-dd HH:mm:ss') : null
   });
+});
+
+// GET /test-warp-ip - 测试WARP出口IP
+app.get('/test-warp-ip', requireAuth, async (req, res) => {
+  try {
+    log('开始测试WARP出口IP...');
+
+    // 检查WARP代理配置
+    const warpEnabled = process.env.WARP_ENABLED === 'true';
+    const warpSocks5Host = process.env.WARP_SOCKS5_HOST;
+    const warpSocks5Port = process.env.WARP_SOCKS5_PORT;
+
+    if (!warpEnabled || !warpSocks5Host || !warpSocks5Port) {
+      return res.status(400).json({
+        success: false,
+        message: 'WARP代理未启用或配置不完整'
+      });
+    }
+
+    const launchArgs = [
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+      '--disable-dev-shm-usage',
+      `--proxy-server=socks5://${warpSocks5Host}:${warpSocks5Port}`
+    ];
+
+    const browser = await puppeteer.launch({
+      headless: true,
+      args: launchArgs,
+      ...(isLocal ? { slowMo: 50 } : {}),
+    });
+
+    const page = await browser.newPage();
+
+    // 访问IP查询服务
+    log('访问IP查询服务...');
+    await page.goto('https://httpbin.org/ip', { waitUntil: 'networkidle2' });
+
+    // 获取出口IP
+    const ipInfo = await page.evaluate(() => {
+      try {
+        const bodyText = document.body.innerText;
+        const ipMatch = bodyText.match(/"origin":\s*"([^"]+)"/);
+        return ipMatch ? ipMatch[1] : null;
+      } catch (error) {
+        return null;
+      }
+    });
+
+    await browser.close();
+
+    if (ipInfo) {
+      log(`WARP出口IP测试成功: ${ipInfo}`);
+      res.json({
+        success: true,
+        message: 'WARP出口IP测试成功',
+        ip: ipInfo,
+        proxy: `socks5://${warpSocks5Host}:${warpSocks5Port}`
+      });
+    } else {
+      log('WARP出口IP测试失败：无法获取IP信息');
+      res.status(500).json({
+        success: false,
+        message: '无法获取IP信息'
+      });
+    }
+  } catch (error) {
+    log(`WARP出口IP测试出错: ${error.message}`);
+    res.status(500).json({
+      success: false,
+      message: `测试失败: ${error.message}`
+    });
+  }
 });
 
 // GET /schedule - 获取定时配置

--- a/start-render.sh
+++ b/start-render.sh
@@ -7,10 +7,13 @@ set -e
 
 echo "启动Render环境中的Hostloc Puppeteer应用..."
 
+# 设置PATH包含当前目录（确保能找到wireproxy）
+export PATH="$PWD:$PATH"
+
 # 检查wireproxy是否已安装
 if ! command -v wireproxy &> /dev/null; then
-    echo "WireProxy未安装，尝试安装..."
-    go install github.com/pufferffish/wireproxy/cmd/wireproxy@latest
+    echo "错误: WireProxy未找到，请检查构建过程"
+    exit 1
 fi
 
 # 检查配置文件是否存在

--- a/start-render.sh
+++ b/start-render.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Render平台启动脚本
+# 同时启动WireProxy和Node.js应用
+
+set -e
+
+echo "启动Render环境中的Hostloc Puppeteer应用..."
+
+# 检查wireproxy是否已安装
+if ! command -v wireproxy &> /dev/null; then
+    echo "WireProxy未安装，尝试安装..."
+    go install github.com/pufferffish/wireproxy/cmd/wireproxy@latest
+fi
+
+# 检查配置文件是否存在
+if [ ! -f "wireproxy.conf" ]; then
+    echo "错误: wireproxy.conf配置文件不存在"
+    exit 1
+fi
+
+# 检查WARP_PRIVATE_KEY环境变量
+if [ -z "$WARP_PRIVATE_KEY" ]; then
+    echo "错误: WARP_PRIVATE_KEY环境变量未设置"
+    exit 1
+fi
+
+# 设置WARP_PRIVATE_KEY环境变量
+export WARP_PRIVATE_KEY=${WARP_PRIVATE_KEY}
+
+# 使用envsubst替换配置文件中的环境变量
+envsubst < wireproxy.conf > wireproxy.conf.tmp
+
+# 启动WireProxy
+echo "启动WireProxy..."
+wireproxy -c wireproxy.conf.tmp &
+
+# 等待WireProxy启动
+sleep 5
+
+# 设置环境变量供Puppeteer使用
+export WARP_ENABLED=true
+export WARP_SOCKS5_HOST=127.0.0.1
+export WARP_SOCKS5_PORT=1080
+
+echo "WARP WireProxy已启动"
+echo "SOCKS5代理地址: socks5://127.0.0.1:1080"
+echo "环境变量已设置:"
+echo "  WARP_ENABLED=$WARP_ENABLED"
+echo "  WARP_SOCKS5_HOST=$WARP_SOCKS5_HOST"
+echo "  WARP_SOCKS5_PORT=$WARP_SOCKS5_PORT"
+
+# 启动Node.js应用
+echo "启动Node.js应用..."
+exec npm start

--- a/start-warp.sh
+++ b/start-warp.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# WARP WireProxy 启动脚本
+# 用于启动WireProxy并设置环境变量供Puppeteer使用
+
+set -e
+
+echo "启动WARP WireProxy..."
+
+# 检查wireproxy是否已安装
+if ! command -v wireproxy &> /dev/null; then
+    echo "WireProxy未安装，尝试安装..."
+    go install github.com/pufferffish/wireproxy/cmd/wireproxy@latest
+fi
+
+# 检查配置文件是否存在
+if [ ! -f "wireproxy.conf" ]; then
+    echo "错误: wireproxy.conf配置文件不存在"
+    exit 1
+fi
+
+# 启动WireProxy
+echo "启动WireProxy..."
+wireproxy -c wireproxy.conf &
+
+# 等待WireProxy启动
+sleep 3
+
+# 设置环境变量
+export WARP_ENABLED=true
+export WARP_SOCKS5_HOST=127.0.0.1
+export WARP_SOCKS5_PORT=1080
+
+echo "WARP WireProxy已启动"
+echo "SOCKS5代理地址: socks5://127.0.0.1:1080"
+echo "环境变量已设置:"
+echo "  WARP_ENABLED=$WARP_ENABLED"
+echo "  WARP_SOCKS5_HOST=$WARP_SOCKS5_HOST"
+echo "  WARP_SOCKS5_PORT=$WARP_SOCKS5_PORT"
+
+# 保持脚本运行
+wait

--- a/start-warp.sh
+++ b/start-warp.sh
@@ -19,9 +19,21 @@ if [ ! -f "wireproxy.conf" ]; then
     exit 1
 fi
 
+# 检查WARP_PRIVATE_KEY环境变量
+if [ -z "$WARP_PRIVATE_KEY" ]; then
+    echo "错误: WARP_PRIVATE_KEY环境变量未设置"
+    exit 1
+fi
+
+# 设置WARP_PRIVATE_KEY环境变量（如果未设置，使用默认值）
+export WARP_PRIVATE_KEY=${WARP_PRIVATE_KEY}
+
+# 使用envsubst替换配置文件中的环境变量
+envsubst < wireproxy.conf > wireproxy.conf.tmp
+
 # 启动WireProxy
 echo "启动WireProxy..."
-wireproxy -c wireproxy.conf &
+wireproxy -c wireproxy.conf.tmp &
 
 # 等待WireProxy启动
 sleep 3

--- a/wgcf-profile.conf.template
+++ b/wgcf-profile.conf.template
@@ -1,0 +1,9 @@
+[Interface]
+PrivateKey = YOUR_PRIVATE_KEY_HERE
+Address = 172.16.0.2/32
+DNS = 1.1.1.1
+
+[Peer]
+PublicKey = bmXOC+F1FxEMF9dyiK2H5/1SUtzH0JuVo51h2wPfgyo=
+Endpoint = engage.cloudflareclient.com:2408
+AllowedIPs = 0.0.0.0/0

--- a/wireproxy.conf
+++ b/wireproxy.conf
@@ -3,7 +3,7 @@
 
 [Interface]
 Address = 172.16.0.2/32
-PrivateKey = YOUR_PRIVATE_KEY_HERE
+PrivateKey = ${WARP_PRIVATE_KEY}
 DNS = 1.1.1.1
 
 [Peer]

--- a/wireproxy.conf
+++ b/wireproxy.conf
@@ -1,0 +1,16 @@
+# WireProxy configuration for WARP
+# This file should be generated from wgcf-profile.conf
+
+[Interface]
+Address = 172.16.0.2/32
+PrivateKey = YOUR_PRIVATE_KEY_HERE
+DNS = 1.1.1.1
+
+[Peer]
+PublicKey = bmXOC+F1FxEMF9dyiK2H5/1SUtzH0JuVo51h2wPfgyo=
+Endpoint = engage.cloudflareclient.com:2408
+AllowedIPs = 0.0.0.0/0
+
+# SOCKS5 proxy for Puppeteer
+[Socks5]
+BindAddress = 127.0.0.1:1080


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add Cloudflare WARP proxy support via WireProxy to route Puppeteer traffic through a SOCKS5 proxy. Also adds an exit‑IP test UI/API and Render build/start scripts for easier deployment.

- **New Features**
  - Puppeteer uses SOCKS5 when WARP_ENABLED=true (reads WARP_SOCKS5_HOST/PORT).
  - New /test-warp-ip endpoint and dashboard button to verify WARP exit IP.
  - Render support: build-render.sh installs Chrome and prebuilt WireProxy; start-render.sh launches WireProxy, exports WARP_* envs, then starts the app. start-warp.sh added for local use.
  - New configs: wireproxy.conf (env-templated with WARP_PRIVATE_KEY) and wgcf-profile.conf.template; package.json adds render/build-render scripts; .gitignore updated for wgcf artifacts.

- **Migration**
  - Provide WARP_PRIVATE_KEY as a secret (from your WARP/WGCF profile).
  - On Render: set Build Command to npm run build-render and Start Command to npm run render.
  - Local/dev: run ./start-warp.sh (or start your own WireProxy and set WARP_* envs), then npm start.

<!-- End of auto-generated description by cubic. -->

